### PR TITLE
Allow "MFC-after" in addition to "MFC after"

### DIFF
--- a/mfctracker/management/commands/importcommits.py
+++ b/mfctracker/management/commands/importcommits.py
@@ -178,7 +178,7 @@ class Command(BaseCommand):
     def parse_mfc_entry(self, msg, commit_date):
         lines = msg.split('\n')
         for line in lines:
-            if re.match('^\s*mfc\s+after\s*:', line, flags=re.IGNORECASE):
+            if re.match('^\s*mfc(-|\s+)after\s*:', line, flags=re.IGNORECASE):
                 calendar = parsedatetime.Calendar()
                 mfc_after_st, parsed = calendar.parse(line, commit_date)
                 if parsed:

--- a/mfctracker/views.py
+++ b/mfctracker/views.py
@@ -138,7 +138,7 @@ def mfc_commit_message(hashes, user, summarized=False):
     commit_msg = None
     if len(hashes) > 0:
         commit_msg = ''
-        mfc_re = re.compile('^MFC\s+after:.*\n?', re.IGNORECASE | re.MULTILINE)
+        mfc_re = re.compile('^MFC(-|\s+)after:.*\n?', re.IGNORECASE | re.MULTILINE)
         for commit in commits:
             if summarized:
                 commit_msg = commit_msg + '\n' + commit.sha_abbr + ': '


### PR DESCRIPTION
imp's transition documents tout interlacing hyphens as the new convention to
follow along with other git projects. Spaces are still allowed for some
unspecified transitional period, so let's accept both here.